### PR TITLE
feature/add-drops-captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ If a position isn't given, then the piece is inferred as being in hand for that 
 
 ## Piece Movement
 
-Piece movement is denoted by `{Player}{PieceType}{CurrentPosition}-{TargetPosition}`, for instance `1: ☗P77-76`.
+Piece movement is denoted by `{Player}{PieceType}{CurrentPosition}{Movement}{TargetPosition}{Promotion}`. 
+
+`{Promotion}` is optional, while if `{Player}` isn't specified, Sente is chosen by default. `{CurrentPosition}` is needed for all movement types, except drops. Movement is denoted by `-`, `x` and `*`, that is, simple movement, capture and drop respectfully. Some examples:
+ 
+| Type            | Example  | Explanation                                                                   |
+|-----------------|----------|-------------------------------------------------------------------------------|
+| Simple movement | ☗P77-76  | Sente's pawn moves from 77 to 76.                                             |
+| Capture         | ☗P75x74  | Sente's pawn moves from 77 to 74 and captures the piece at 74.                |
+| Drop            | ☗S*34    | Sente's drops a silver from in hand onto 34.                                  |
+| Combined        | ☗S34x33+ | Sente's silver moves from 34 to 33, captures the piece at 33 and is promoted. |
+
 
 Thus, given an initial board for Sente, a *Yagura castle* could be build using the following moves:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dependencies:
   shogi:
 ```
 
-Note that this package requires dart >= 2.3.0.
+Note that this package requires dart >= 2.6.0.
 
 ### Example
 

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,7 @@ dependencies:
   shogi:
 ```
 
-Note that this package requires dart >= 2.3.0.
+Note that this package requires dart >= 2.6.0.
 
 ## Example
 

--- a/lib/src/enums/piece_type.dart
+++ b/lib/src/enums/piece_type.dart
@@ -15,3 +15,32 @@ enum PieceType {
   lancePromoted,
   pawnPromoted,
 }
+
+/// A class of extensions for PieceType
+extension PieceTypeExtensions on PieceType {
+  /// A list of piece types which can be promoted
+  static const piecesWhichCanBePromoted = const [
+    PieceType.pawn,
+    PieceType.lance,
+    PieceType.knight,
+    PieceType.silver,
+    PieceType.bishop,
+    PieceType.rook,
+  ];
+
+  /// A map of piece type and their promoted equivalents
+  static const convertPieceTypeToPromotedPieceType = const {
+    PieceType.pawn: PieceType.pawnPromoted,
+    PieceType.lance: PieceType.lancePromoted,
+    PieceType.knight: PieceType.knightPromoted,
+    PieceType.silver: PieceType.silverPromoted,
+    PieceType.bishop: PieceType.bishopPromoted,
+    PieceType.rook: PieceType.rookPromoted,
+  };
+
+  /// Whether the piece type can be promoted
+  bool get canBePromoted => piecesWhichCanBePromoted.contains(this);
+
+  /// Returns a promoted equivalent for the piece type. Returns `null` if the piece type cannot be promoted.
+  PieceType get promoted => this.canBePromoted ? convertPieceTypeToPromotedPieceType[this] : null;
+}

--- a/lib/src/enums/piece_type.dart
+++ b/lib/src/enums/piece_type.dart
@@ -48,6 +48,7 @@ extension PieceTypeExtensions on PieceType {
     PieceType.rook: PieceType.rookPromoted,
   };
 
+  /// A map of promoted piece types and their standard equivalents
   static final convertPromotedPieceTypeToPieceType = convertPieceTypeToPromotedPieceType.map((k, v) => MapEntry(v, k));
 
   /// Whether the piece type can be promoted

--- a/lib/src/enums/piece_type.dart
+++ b/lib/src/enums/piece_type.dart
@@ -28,6 +28,16 @@ extension PieceTypeExtensions on PieceType {
     PieceType.rook,
   ];
 
+  /// A list of promoted piece types
+  static const promotedPieces = const [
+    PieceType.pawnPromoted,
+    PieceType.lancePromoted,
+    PieceType.knightPromoted,
+    PieceType.silverPromoted,
+    PieceType.bishopPromoted,
+    PieceType.rookPromoted,
+  ];
+
   /// A map of piece type and their promoted equivalents
   static const convertPieceTypeToPromotedPieceType = const {
     PieceType.pawn: PieceType.pawnPromoted,
@@ -38,9 +48,17 @@ extension PieceTypeExtensions on PieceType {
     PieceType.rook: PieceType.rookPromoted,
   };
 
+  static final convertPromotedPieceTypeToPieceType = convertPieceTypeToPromotedPieceType.map((k, v) => MapEntry(v, k));
+
   /// Whether the piece type can be promoted
   bool get canBePromoted => piecesWhichCanBePromoted.contains(this);
 
   /// Returns a promoted equivalent for the piece type. Returns `null` if the piece type cannot be promoted.
-  PieceType get promoted => this.canBePromoted ? convertPieceTypeToPromotedPieceType[this] : null;
+  PieceType promote() => this.canBePromoted ? convertPieceTypeToPromotedPieceType[this] : null;
+
+  /// Whether the piece type is promoted
+  bool get isPromoted => promotedPieces.contains(this);
+
+  /// Returns a normalized equivalent for the piece type (i.e. PieceType.pawnPromoted => PieceType.pawn).
+  PieceType normalize() => this.isPromoted ? convertPromotedPieceTypeToPieceType[this] : this;
 }

--- a/lib/src/enums/player_type.dart
+++ b/lib/src/enums/player_type.dart
@@ -3,3 +3,15 @@ enum PlayerType {
   sente,
   gote,
 }
+
+/// A class of extensions for PlayerType
+extension PlayerTypeExtensions on PlayerType {
+  /// Whether the player type is sente
+  bool get isSente => this == PlayerType.sente;
+
+  /// Whether the player type is gote
+  bool get isGote => this == PlayerType.gote;
+
+  /// Flips the player type, i.e. `PlayerType.sente` => `PlayerType.gote`
+  PlayerType flip() => this.isSente ? PlayerType.gote : PlayerType.sente;
+}

--- a/lib/src/models/board_piece.dart
+++ b/lib/src/models/board_piece.dart
@@ -38,20 +38,14 @@ class BoardPiece {
         assert(player != null);
 
   /// Whether the piece belongs to sente
-  bool get isSente => player == PlayerType.sente;
+  bool get isSente => player.isSente;
 
   /// The pieces display string
   String displayString({bool usesJapanese = true}) =>
       PackageUtils.pieceTypeToString(pieceType, usesJapanese: usesJapanese, isSente: isSente);
 
   /// Whether the piece is promoted
-  bool get isPromoted =>
-      pieceType == PieceType.rookPromoted ||
-      pieceType == PieceType.bishopPromoted ||
-      pieceType == PieceType.silverPromoted ||
-      pieceType == PieceType.knightPromoted ||
-      pieceType == PieceType.lancePromoted ||
-      pieceType == PieceType.pawnPromoted;
+  bool get isPromoted => pieceType.isPromoted;
 
   @override
   bool operator ==(dynamic other) =>

--- a/lib/src/models/board_piece.dart
+++ b/lib/src/models/board_piece.dart
@@ -53,6 +53,13 @@ class BoardPiece {
       pieceType == PieceType.lancePromoted ||
       pieceType == PieceType.pawnPromoted;
 
+  @override
+  bool operator ==(dynamic other) =>
+      other is BoardPiece && position == other.position && player == other.player && pieceType == other.pieceType;
+
+  @override
+  int get hashCode => player.hashCode ^ pieceType.hashCode ^ position.hashCode;
+
   /// Returns a string representation of the model
   @override
   String toString() =>

--- a/lib/src/models/move.dart
+++ b/lib/src/models/move.dart
@@ -14,21 +14,40 @@ class Move {
   final PieceType piece;
 
   /// The original position
+  ///
+  /// `null` if piece is dropped onto the board
   final Position from;
 
   /// The new position
   final Position to;
+
+  /// Whether the move promotes the piece
+  final bool isPromotion;
+
+  /// Whether the move captures an oppenent's piece
+  final bool isCapture;
+
+  /// Whether the move drops a piece onto the board
+  final bool isDrop;
 
   const Move({
     @required this.player,
     @required this.piece,
     @required this.from,
     @required this.to,
+    this.isPromotion = false,
+    this.isCapture = false,
+    this.isDrop = false,
   })  : assert(player != null),
         assert(piece != null),
-        assert(from != null),
-        assert(to != null);
+        assert(to != null),
+        assert(isPromotion != null),
+        assert(isCapture != null),
+        assert(isDrop != null),
+        assert(!(isPromotion && isDrop)), //a move cannot have isDrop and isPromotion
+        assert(isDrop ? from == null : from != null); //if isDrop, from should not be null otherwise should be null
 
   @override
-  String toString() => '${DartUtils.describeEnum(player)} with ${DartUtils.describeEnum(piece)} from $from to $to';
+  String toString() =>
+      '${DartUtils.describeEnum(player)} with ${DartUtils.describeEnum(piece)} from $from to $to. isPromotion: $isPromotion, isCapture: $isCapture, isDrop: $isDrop.';
 }

--- a/lib/src/models/move.dart
+++ b/lib/src/models/move.dart
@@ -48,6 +48,19 @@ class Move {
         assert(isDrop ? from == null : from != null); //if isDrop, from should not be null otherwise should be null
 
   @override
+  bool operator ==(dynamic other) =>
+      other is Move &&
+      player == other.player &&
+      from == other.from &&
+      to == other.to &&
+      isPromotion == other.isPromotion &&
+      isCapture == other.isCapture &&
+      isDrop == other.isDrop;
+
+  @override
+  int get hashCode => player.hashCode ^ from.hashCode ^ to.hashCode;
+
+  @override
   String toString() =>
       '${DartUtils.describeEnum(player)} with ${DartUtils.describeEnum(piece)} from $from to $to. isPromotion: $isPromotion, isCapture: $isCapture, isDrop: $isDrop.';
 }

--- a/lib/src/models/position.dart
+++ b/lib/src/models/position.dart
@@ -20,6 +20,20 @@ class Position {
   })  : assert(column >= 1 && column <= BoardConfig.numberColumns),
         assert(row >= 1 && row <= BoardConfig.numberRows);
 
+  /// Constructs a `Position` from a string `11`
+  ///
+  /// Note that this can return `null`!!
+  factory Position.fromString(String position) {
+    if (position != null && position.length == 2) {
+      return Position(
+        column: int.tryParse(position[0]),
+        row: int.tryParse(position[1]),
+      );
+    }
+
+    return null;
+  }
+
   @override
   bool operator ==(dynamic otherPosition) =>
       otherPosition is Position && row == otherPosition.row && column == otherPosition.column;

--- a/lib/src/models/position.dart
+++ b/lib/src/models/position.dart
@@ -35,8 +35,7 @@ class Position {
   }
 
   @override
-  bool operator ==(dynamic otherPosition) =>
-      otherPosition is Position && row == otherPosition.row && column == otherPosition.column;
+  bool operator ==(dynamic other) => other is Position && row == other.row && column == other.column;
 
   @override
   int get hashCode => row.hashCode ^ column.hashCode;

--- a/lib/src/services/custom_notation_converter.dart
+++ b/lib/src/services/custom_notation_converter.dart
@@ -1,11 +1,35 @@
 import 'i_notation_converter.dart';
+import '../configs/board_config.dart';
 import '../enums/player_type.dart';
 import '../models/move.dart';
 import '../models/position.dart';
 import '../utils/package_utils.dart';
 
+/// An enum describing the types of capture groups
+enum _CaptureGroup {
+  player,
+  piece,
+  from,
+  movement,
+  to,
+  promotion,
+}
+
 /// A service which uses a custom notation developed for this package
 class CustomNotationConverter implements INotationConverter {
+  /// The symbol used to represent simple movement
+  /// ignore: unused_field
+  static const _moveSymbol = '-';
+
+  /// The symbol used to represent capture
+  static const _captureSymbol = 'x';
+
+  /// The symbol used to represent a drop
+  static const _dropSymbol = '*';
+
+  /// The symbol used to represent promotion
+  static const _promotionSymbol = '+';
+
   /// Converts a game of the form
   ///
   /// ```
@@ -17,32 +41,62 @@ class CustomNotationConverter implements INotationConverter {
   @override
   List<Move> movesFromFile(String file) {
     if (file != null) {
+      /// firstly split file into a list of moves, ignoring any prepending number indicators
       final movesAsText = file.replaceAll(RegExp(r'\d+\:\s'), '').split('\n');
       movesAsText.remove(''); // remove any empty strings
 
       final moves = <Move>[];
       for (final moveAsText in movesAsText) {
-        try {
-          final player = moveAsText[0] == '☗' ? PlayerType.sente : PlayerType.gote;
-          final piece = PackageUtils.pieceStringToType(moveAsText[1]);
+        // convert the move into a list of components
+        final components = _convertMoveAsTextIntoComponents(moveAsText);
 
-          final from = Position(column: int.parse(moveAsText[2]), row: int.parse(moveAsText[3]));
-          final to = Position(column: int.parse(moveAsText[5]), row: int.parse(moveAsText[6]));
+        // parse each component
+        final player = components[_CaptureGroup.player.index] == BoardConfig.gote ? PlayerType.gote : PlayerType.sente;
+        final piece = PackageUtils.pieceStringToType(components[_CaptureGroup.piece.index]);
+        final from = Position.fromString(components[_CaptureGroup.from.index]);
+        final isCapture = components[_CaptureGroup.movement.index] == _captureSymbol;
+        final isDrop = components[_CaptureGroup.movement.index] == _dropSymbol;
+        final to = Position.fromString(components[_CaptureGroup.to.index]);
+        final isPromotion = components[_CaptureGroup.promotion.index] == _promotionSymbol;
 
-          moves.add(
-            Move(
-              player: player,
-              piece: piece,
-              from: from,
-              to: to,
-            ),
-          );
-        } catch (_) {}
+        moves.add(
+          Move(
+            player: player,
+            piece: piece,
+            from: from,
+            to: to,
+            isCapture: isCapture,
+            isDrop: isDrop,
+            isPromotion: isPromotion,
+          ),
+        );
       }
 
       return moves;
     }
 
     return null;
+  }
+
+  /// A regexp used to parse all potential moves
+  ///
+  /// 1. player type, either ☗ or ☖
+  /// 2. piece type, i.e. K, P, +R
+  /// 3. from, assumed to be two digits i.e. 11 (optional)
+  /// 4. movement type, i.e. -, * or x
+  /// 5. to, assumed to be two digits i.e. 11
+  /// 6. promotion, can only match to + (optional)
+  static final _regExp = RegExp(r'([☗|☖])(\w)(\d{2})?([-|\*|x])(\d{2})(\+)?');
+
+  /// The number of groups captured by `_regExp`
+  static const _numberCaptureGroups = 6;
+
+  /// A list of group indeces from 1 to 6, used to get all matched groups from `_regExp`
+  static final _groupIndeces = List.generate(_numberCaptureGroups, (index) => index + 1);
+
+  /// Converts a move `☗S34x33+` into `[☗, S, 34, x,33, +]`
+  List<String> _convertMoveAsTextIntoComponents(String moveAsText) {
+    final matches = _regExp.allMatches(moveAsText);
+    return matches?.first?.groups(_groupIndeces);
   }
 }

--- a/lib/src/services/custom_notation_converter.dart
+++ b/lib/src/services/custom_notation_converter.dart
@@ -86,7 +86,7 @@ class CustomNotationConverter implements INotationConverter {
   /// 4. movement type, i.e. -, * or x
   /// 5. to, assumed to be two digits i.e. 11
   /// 6. promotion, can only match to + (optional)
-  static final _regExp = RegExp(r'([☗|☖])(\w)(\d{2})?([-|\*|x])(\d{2})(\+)?');
+  static final _regExp = RegExp(r'([☗☖])(P|L|N|S|G|K|B|R|\+P|\+L|\+N|\+S|\+B|\+R)(\d{2})?([-\*x])(\d{2})(\+)?');
 
   /// The number of groups captured by `_regExp`
   static const _numberCaptureGroups = 6;

--- a/lib/src/services/custom_notation_converter.dart
+++ b/lib/src/services/custom_notation_converter.dart
@@ -49,27 +49,29 @@ class CustomNotationConverter implements INotationConverter {
       for (final moveAsText in movesAsText) {
         // convert the move into a list of components
         final components = _convertMoveAsTextIntoComponents(moveAsText);
+        if (components != null) {
+          // parse each component
+          final player =
+              components[_CaptureGroup.player.index] == BoardConfig.gote ? PlayerType.gote : PlayerType.sente;
+          final piece = PackageUtils.pieceStringToType(components[_CaptureGroup.piece.index]);
+          final from = Position.fromString(components[_CaptureGroup.from.index]);
+          final isCapture = components[_CaptureGroup.movement.index] == _captureSymbol;
+          final isDrop = components[_CaptureGroup.movement.index] == _dropSymbol;
+          final to = Position.fromString(components[_CaptureGroup.to.index]);
+          final isPromotion = components[_CaptureGroup.promotion.index] == _promotionSymbol;
 
-        // parse each component
-        final player = components[_CaptureGroup.player.index] == BoardConfig.gote ? PlayerType.gote : PlayerType.sente;
-        final piece = PackageUtils.pieceStringToType(components[_CaptureGroup.piece.index]);
-        final from = Position.fromString(components[_CaptureGroup.from.index]);
-        final isCapture = components[_CaptureGroup.movement.index] == _captureSymbol;
-        final isDrop = components[_CaptureGroup.movement.index] == _dropSymbol;
-        final to = Position.fromString(components[_CaptureGroup.to.index]);
-        final isPromotion = components[_CaptureGroup.promotion.index] == _promotionSymbol;
-
-        moves.add(
-          Move(
-            player: player,
-            piece: piece,
-            from: from,
-            to: to,
-            isCapture: isCapture,
-            isDrop: isDrop,
-            isPromotion: isPromotion,
-          ),
-        );
+          moves.add(
+            Move(
+              player: player,
+              piece: piece,
+              from: from,
+              to: to,
+              isCapture: isCapture,
+              isDrop: isDrop,
+              isPromotion: isPromotion,
+            ),
+          );
+        }
       }
 
       return moves;
@@ -97,6 +99,6 @@ class CustomNotationConverter implements INotationConverter {
   /// Converts a move `☗S34x33+` into `[☗, S, 34, x,33, +]`
   List<String> _convertMoveAsTextIntoComponents(String moveAsText) {
     final matches = _regExp.allMatches(moveAsText);
-    return matches?.first?.groups(_groupIndeces);
+    return matches.length == 1 ? matches?.first?.groups(_groupIndeces) : null;
   }
 }

--- a/lib/src/services/game_engine.dart
+++ b/lib/src/services/game_engine.dart
@@ -15,7 +15,7 @@ class GameEngine {
     final gotePiecesInHand = List<BoardPiece>.from(gameBoard.gotePiecesInHand);
 
     if (move.isDrop) {
-      final list = move.player == PlayerType.sente ? sentePiecesInHand : gotePiecesInHand;
+      final list = move.player.isSente ? sentePiecesInHand : gotePiecesInHand;
       final droppedPiece = list.firstWhere((piece) => piece.pieceType == move.piece);
       list.remove(droppedPiece);
 
@@ -31,7 +31,7 @@ class GameEngine {
         final capturedPiece = boardPieces.firstWhere((piece) => piece.position == move.to);
         boardPieces.remove(capturedPiece);
 
-        final list = move.player == PlayerType.sente ? sentePiecesInHand : gotePiecesInHand;
+        final list = move.player.isSente ? sentePiecesInHand : gotePiecesInHand;
         list.add(
           BoardPiece(
             player: move.player,

--- a/lib/src/utils/shogi_utils.dart
+++ b/lib/src/utils/shogi_utils.dart
@@ -16,11 +16,11 @@ class ShogiUtils {
     final boardPieces = stringArrayToBoardPiecesArray(strPieces);
 
     final List<BoardPiece> sentePiecesInHand =
-        boardPieces.where((piece) => piece.position == null && piece.player == PlayerType.sente).toList();
+        boardPieces.where((piece) => piece.position == null && piece.player.isSente).toList();
     _removeElementsFromList(boardPieces, sentePiecesInHand);
 
     final List<BoardPiece> gotePiecesInHand =
-        boardPieces.where((piece) => piece.position == null && piece.player == PlayerType.gote).toList();
+        boardPieces.where((piece) => piece.position == null && piece.player.isGote).toList();
     _removeElementsFromList(boardPieces, gotePiecesInHand);
 
     return GameBoard(
@@ -76,7 +76,6 @@ class ShogiUtils {
     for (final piece in originalPieces) {
       final newRow = (piece.position.row - BoardConfig.numberRows).abs() + 1;
       final newColumn = (piece.position.column - BoardConfig.numberColumns).abs() + 1;
-      final newPlayer = piece.player == PlayerType.gote ? PlayerType.sente : PlayerType.gote;
 
       newPieces.add(
         BoardPiece(
@@ -85,7 +84,7 @@ class ShogiUtils {
             column: newColumn,
           ),
           pieceType: piece.pieceType,
-          player: newPlayer,
+          player: piece.player.flip(),
         ),
       );
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,4 +185,4 @@ packages:
     source: hosted
     version: "3.5.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 homepage: https://github.com/defuncart/shogi
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/enums/piece_type_test.dart
+++ b/test/enums/piece_type_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shogi/shogi.dart';
+
+main() {
+  test('PieceType.pawn', () {
+    final pieceType = PieceType.pawn;
+    expect(pieceType.canBePromoted, true);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), PieceType.pawnPromoted);
+    expect(pieceType.normalize(), PieceType.pawn);
+  });
+
+  test('PieceType.lance', () {
+    final pieceType = PieceType.lance;
+    expect(pieceType.canBePromoted, true);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), PieceType.lancePromoted);
+    expect(pieceType.normalize(), PieceType.lance);
+  });
+
+  test('PieceType.knight', () {
+    final pieceType = PieceType.knight;
+    expect(pieceType.canBePromoted, true);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), PieceType.knightPromoted);
+    expect(pieceType.normalize(), PieceType.knight);
+  });
+
+  test('PieceType.silver', () {
+    final pieceType = PieceType.silver;
+    expect(pieceType.canBePromoted, true);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), PieceType.silverPromoted);
+    expect(pieceType.normalize(), PieceType.silver);
+  });
+
+  test('PieceType.gold', () {
+    final pieceType = PieceType.gold;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.gold);
+  });
+
+  test('PieceType.king', () {
+    final pieceType = PieceType.king;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.king);
+  });
+
+  test('PieceType.bishop', () {
+    final pieceType = PieceType.bishop;
+    expect(pieceType.canBePromoted, true);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), PieceType.bishopPromoted);
+    expect(pieceType.normalize(), PieceType.bishop);
+  });
+
+  test('PieceType.rook', () {
+    final pieceType = PieceType.rook;
+    expect(pieceType.canBePromoted, true);
+    expect(pieceType.isPromoted, false);
+    expect(pieceType.promote(), PieceType.rookPromoted);
+    expect(pieceType.normalize(), PieceType.rook);
+  });
+
+  test('PieceType.pawnPromoted', () {
+    final pieceType = PieceType.pawnPromoted;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, true);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.pawn);
+  });
+
+  test('PieceType.lancePromoted', () {
+    final pieceType = PieceType.lancePromoted;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, true);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.lance);
+  });
+
+  test('PieceType.knightPromoted', () {
+    final pieceType = PieceType.knightPromoted;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, true);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.knight);
+  });
+
+  test('PieceType.silverPromoted', () {
+    final pieceType = PieceType.silverPromoted;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, true);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.silver);
+  });
+
+  test('PieceType.bishopPromoted', () {
+    final pieceType = PieceType.bishopPromoted;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, true);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.bishop);
+  });
+
+  test('PieceType.rookPromoted', () {
+    final pieceType = PieceType.rookPromoted;
+    expect(pieceType.canBePromoted, false);
+    expect(pieceType.isPromoted, true);
+    expect(pieceType.promote(), null);
+    expect(pieceType.normalize(), PieceType.rook);
+  });
+}

--- a/test/enums/player_type_test.dart
+++ b/test/enums/player_type_test.dart
@@ -2,13 +2,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shogi/shogi.dart';
 
 main() {
-  test('PlayerType', () {
-    var playerType = PlayerType.sente;
+  test('PlayerType.sente', () {
+    final playerType = PlayerType.sente;
     expect(playerType.isSente, true);
     expect(playerType.isGote, false);
     expect(playerType.flip(), PlayerType.gote);
+  });
 
-    playerType = PlayerType.gote;
+  test('PlayerType.gote', () {
+    final playerType = PlayerType.gote;
     expect(playerType.isSente, false);
     expect(playerType.isGote, true);
     expect(playerType.flip(), PlayerType.sente);

--- a/test/enums/player_type_test.dart
+++ b/test/enums/player_type_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shogi/shogi.dart';
+
+main() {
+  test('PlayerType', () {
+    var playerType = PlayerType.sente;
+    expect(playerType.isSente, true);
+    expect(playerType.isGote, false);
+    expect(playerType.flip(), PlayerType.gote);
+
+    playerType = PlayerType.gote;
+    expect(playerType.isSente, false);
+    expect(playerType.isGote, true);
+    expect(playerType.flip(), PlayerType.sente);
+  });
+}

--- a/test/services/game_engine_test.dart
+++ b/test/services/game_engine_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shogi/shogi.dart';
+
+main() {
+  test('GameEngine.makeMove()', () {
+    const initialBoard = const [
+      '☖:K-51',
+      '☖:S-52',
+      '☗:P-53',
+    ];
+
+    final movesFile = """
+☗P53x52+
+☖K51x52
+""";
+
+    final converter = CustomNotationConverter();
+    var gameBoard = ShogiUtils.stringArrayToGameBoard(initialBoard);
+    expect(gameBoard.boardPieces, [
+      BoardPiece(
+        player: PlayerType.gote,
+        pieceType: PieceType.king,
+        position: Position(column: 5, row: 1),
+      ),
+      BoardPiece(
+        player: PlayerType.gote,
+        pieceType: PieceType.silver,
+        position: Position(column: 5, row: 2),
+      ),
+      BoardPiece(
+        player: PlayerType.sente,
+        pieceType: PieceType.pawn,
+        position: Position(column: 5, row: 3),
+      )
+    ]);
+    expect(gameBoard.sentePiecesInHand, []);
+    expect(gameBoard.gotePiecesInHand, []);
+
+    final moves = converter.movesFromFile(movesFile);
+    expect(moves, [
+      Move(
+        player: PlayerType.sente,
+        piece: PieceType.pawn,
+        from: Position(column: 5, row: 3),
+        to: Position(column: 5, row: 2),
+        isDrop: false,
+        isCapture: true,
+        isPromotion: true,
+      ),
+      Move(
+        player: PlayerType.gote,
+        piece: PieceType.king,
+        from: Position(column: 5, row: 1),
+        to: Position(column: 5, row: 2),
+        isDrop: false,
+        isCapture: true,
+        isPromotion: false,
+      ),
+    ]);
+
+    List<GameBoard> gameBoards = [];
+    for (final move in moves) {
+      gameBoard = GameEngine.makeMove(gameBoard, move);
+      gameBoards.add(gameBoard);
+    }
+
+    gameBoard = gameBoards[0];
+    expect(gameBoard.boardPieces, [
+      BoardPiece(
+        player: PlayerType.gote,
+        pieceType: PieceType.king,
+        position: Position(column: 5, row: 1),
+      ),
+      BoardPiece(
+        player: PlayerType.sente,
+        pieceType: PieceType.pawnPromoted,
+        position: Position(column: 5, row: 2),
+      )
+    ]);
+    expect(gameBoard.sentePiecesInHand, [
+      BoardPiece(
+        player: PlayerType.sente,
+        pieceType: PieceType.silver,
+        position: null,
+      ),
+    ]);
+    expect(gameBoard.gotePiecesInHand, []);
+
+    gameBoard = gameBoards[1];
+    expect(gameBoard.boardPieces, [
+      BoardPiece(
+        player: PlayerType.gote,
+        pieceType: PieceType.king,
+        position: Position(column: 5, row: 2),
+      ),
+    ]);
+    expect(gameBoard.sentePiecesInHand, [
+      BoardPiece(
+        player: PlayerType.sente,
+        pieceType: PieceType.silver,
+        position: null,
+      ),
+    ]);
+    expect(gameBoard.gotePiecesInHand, [
+      BoardPiece(
+        player: PlayerType.gote,
+        pieceType: PieceType.pawn,
+        position: null,
+      ),
+    ]);
+  });
+}

--- a/test/utils/dart_utils_test.dart
+++ b/test/utils/dart_utils_test.dart
@@ -1,14 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shogi/src/utils/dart_utils.dart';
 
-enum TestEnum {
+enum _TestEnum {
   value1,
   value2,
 }
 
 main() {
   test('describeEnum', () {
-    final describeEnum = DartUtils.describeEnum(TestEnum.value1);
+    final describeEnum = DartUtils.describeEnum(_TestEnum.value1);
     expect(describeEnum, 'value1');
   });
 }


### PR DESCRIPTION
This PR adds the ability to have moves which don't simple move a piece from positions AB to CD, but also that a piece in hand can be dropped on the other, and that a move can capture an opponents piece.

All moves are now described using `{Player}{PieceType}{CurrentPosition}{Movement}{TargetPosition}{Promotion}`, i.e.  ☗P77-76 , ☗P75x74, ☗S*34, ☗S34x33+ etc.

Also added extensions methods for `PieceType` and `PlayerType`, thus sdk has been raised to >= 2.6. These are far more convenient and readable than helper methods.

Added equality comparison (==) for `BoardPiece` and `Move`.

Added factory constructor `fromString` on `Position`.