### PR TITLE
feature/use lower case for gote latin piece symbols

### DIFF
--- a/lib/src/models/board_piece.dart
+++ b/lib/src/models/board_piece.dart
@@ -3,8 +3,8 @@ import 'package:meta/meta.dart';
 import '../enums/piece_type.dart';
 import '../enums/player_type.dart';
 import '../models/position.dart';
-import '../utils/package_utils.dart';
 import '../utils/dart_utils.dart';
+import '../utils/package_utils.dart';
 
 /// A model representing a shogi board piece
 class BoardPiece {
@@ -42,7 +42,7 @@ class BoardPiece {
 
   /// The pieces display string
   String displayString({bool usesJapanese = true}) =>
-      PackageUtils.pieceTypeToString(pieceType, usesJapanese: usesJapanese, isSente: isSente);
+      PackageUtils.pieceTypeToDisplayString(pieceType, usesJapanese: usesJapanese, isSente: isSente);
 
   /// Whether the piece is promoted
   bool get isPromoted => pieceType.isPromoted;

--- a/lib/src/utils/package_utils.dart
+++ b/lib/src/utils/package_utils.dart
@@ -52,6 +52,17 @@ class PackageUtils {
     }
   }
 
+  /// Converts a piece type to a display string
+  ///
+  /// The difference from `pieceTypeToString` is that gote display strings for latin are in lowercase
+  static String pieceTypeToDisplayString(PieceType pieceType, {bool usesJapanese = true, bool isSente = true}) {
+    if (usesJapanese) {
+      return !isSente && pieceType == PieceType.king ? _kingGoteJP : _piecesJP[pieceType];
+    } else {
+      return isSente ? _piecesEN[pieceType] : _piecesEN[pieceType].toLowerCase();
+    }
+  }
+
   /// Converts a string to piece type
   ///
   /// `usesJapanese` is optional and default to `false`


### PR DESCRIPTION
Adds a new pieceTypeToDisplayString utils which returns symbols for gote in lower case when latin is selected. Japanese remains as before.